### PR TITLE
basic framework for nas-01 filesystems

### DIFF
--- a/hosts/nixos/nas-01/default.nix
+++ b/hosts/nixos/nas-01/default.nix
@@ -172,6 +172,40 @@
             "com.sun:auto-snapshot" = "true";
           };
         };
+
+        # tomcotton tree
+        "local/tomcotton" = {
+          type = "zfs_fs";
+          mountpoint = "/media/tomcotton";
+          options = {
+            mountpoint = "legacy";
+            "com.sun:auto-snapshot" = "false"; # Parent FS, no data
+          };
+        };
+        "local/tomcotton/data" = {
+          type = "zfs_fs";
+          mountpoint = "/media/tomcotton/documents";
+          options = {
+            mountpoint = "legacy";
+            "com.sun:auto-snapshot" = "true"; 
+          };
+        };
+        "local/tomcotton/cold-data" = { # Separated for alternate possible offsite backup method
+          type = "zfs_fs";
+          mountpoint = "/media/tomcotton/documents";
+          options = {
+            mountpoint = "legacy";
+            "com.sun:auto-snapshot" = "true"; 
+          };
+        };
+        "local/tomcotton/audio-library" = {
+          type = "zfs_fs";
+          mountpoint = "/media/tomcotton/audio-library";
+          options = {
+            mountpoint = "legacy";
+            "com.sun:auto-snapshot" = "true"; 
+          };
+        };
       }; # filesystems
     };
     backuppool = {
@@ -201,6 +235,36 @@
             "com.sun:auto-snapshot" = "true";
           };
         };
+        "local/backups/toms-mini" = { # Seperate backups filesystems for simpler snapshotting
+          type = "zfs_fs";
+          mountpoint = "/backups/toms-mini";
+          options = {
+            mountpoint = "legacy";
+            recordsize = "1M"; # for large files
+            "com.sun:auto-snapshot" = "true";
+          };
+        };
+        "local/backups/toms-MBP" = { # Seperate backups filesystems for simpler snapshotting
+          type = "zfs_fs";
+          mountpoint = "/backups/toms-MBP";
+          options = {
+            mountpoint = "legacy";
+            recordsize = "1M"; # for large files
+            "com.sun:auto-snapshot" = "true";
+          };
+        };
+        "local/backups/toms-devices" = { # iPhone etc...
+          type = "zfs_fs";
+          mountpoint = "/backups/toms-devices";
+          options = {
+            mountpoint = "legacy";
+            recordsize = "1M"; # for large files
+            "com.sun:auto-snapshot" = "true";
+          };
+        };
+        # EX: backups/nix-01 
+        # EX: backups/nix-02
+        # EX: etc...
       }; # filesystems
     };
   };


### PR DESCRIPTION
This is the basic idea, however there are some things I'm not sure on. 

First, I think this level of filesystem separation is good. It allows for simpler management of snapshots, especially for rollbacks. While I believe that single file rollbacks are possible, it is quicker to do a filesystem rollback when you are sure that you wont mess with any other files. 

I think the recordsize of the ARQ backup filesystems could be changed to better match ARQ backups. 

Finally, I put in comments outlining what the nix machines' backups could look like, but it might not match how remote nix snapshots work, so take that with a grain of salt. 