### PR TITLE
ghostty doesnt work on mac

### DIFF
--- a/hosts/common/common-packages.nix
+++ b/hosts/common/common-packages.nix
@@ -58,7 +58,6 @@
       #  fira-mono
       fd
       gh
-      inputs.ghostty.packages."${system}".default
       go_1_23
       glow
       go-migrate

--- a/hosts/common/nixos-common.nix
+++ b/hosts/common/nixos-common.nix
@@ -39,6 +39,7 @@ in {
     television
     qemu
     quickemu
+    inputs.ghostty.packages."${system}".default
   ];
 
   ## pins to stable as unstable updates very often


### PR DESCRIPTION
error: Package ‘ghostty-1.1.1’ in /nix/store/qp2mi36pghkngp4d6gwlc8jnlbq7g7hn-source/nix/package.nix:50 is not available on the requested hostPlatform:
         hostPlatform.config = "aarch64-apple-darwin"
         package.meta.platforms = [
           "x86_64-linux"
           "aarch64-linux"
         ]

I had to move this package to have my system build. 