### PR TITLE
Wallabag working

### DIFF
--- a/clubcotton/services/wallabag/default.nix
+++ b/clubcotton/services/wallabag/default.nix
@@ -80,12 +80,16 @@ in {
         "${cfg.dataDir}/images:/var/www/wallabag/web/assets/images"
       ];
       ports = ["${toString cfg.port}:80"];
+      environment = {
+        PUID = toString config.users.users.${cfg.user}.uid;
+        PGID = toString config.users.groups.${cfg.group}.gid;
+      };
     };
 
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir}/data 0777 ${cfg.user} ${cfg.group} - -"
       "d ${cfg.dataDir}/images 0777 ${cfg.user} ${cfg.group} - -"
-      "f ${cfg.dataDir}/data/wallabag.sqlite 0666 ${cfg.user} ${cfg.group} - -"
+      # "f ${cfg.dataDir}/data/wallabag.sqlite 0666 ${cfg.user} ${cfg.group} - -"
     ];
 
     services.tsnsrv = {

--- a/hosts/nixos/nas-01/default.nix
+++ b/hosts/nixos/nas-01/default.nix
@@ -215,7 +215,6 @@
 
   services.clubcotton.wallabag = {
     dataDir = "/media/documents/wallabag";
-  
   };
 
   services.clubcotton.kavita = {


### PR DESCRIPTION
I was able to make a new user, change its password, and make it an admin. However, I don't think that anything I changed actually fixed this, all I did was run `sudo podman exec -it wallabag /bin/sh` and run the wallabag cli tools there. For some reason it worked there and not using `podman run`. The command to promote a user to admin is this `bin/console --env=prod fos:user:promote --super`. 